### PR TITLE
add CustomerProcessor and make Reseller entity an API ressource again

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -22,3 +22,7 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
+    App\State\CustomerProcessor:
+        bind:
+            $persistProcessor: '@api_platform.doctrine.orm.state.persist_processor'
+            $removeProcessor: '@api_platform.doctrine.orm.state.remove_processor'

--- a/src/ApiPlatform/CustomersByResellerExtension.php
+++ b/src/ApiPlatform/CustomersByResellerExtension.php
@@ -7,6 +7,7 @@ use ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Operation;
 use App\Entity\Customer;
+use App\Entity\Reseller;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Bundle\SecurityBundle\Security;
 
@@ -27,16 +28,12 @@ readonly class CustomersByResellerExtension implements QueryCollectionExtensionI
 
     private function customersByReseller(string $resourceClass, QueryBuilder $queryBuilder): void
     {
-        if (Customer::class !== $resourceClass) { return;}
-
-        $rootAlias = $queryBuilder->getRootAliases()[0];
-        $user = $this->security->getUser();
-        if ($user) {
-            $query = $queryBuilder->andWhere($rootAlias.'.reseller = :reseller')
-                ->setParameter('reseller', $user);
-
-//            $queryBuilder->andWhere(sprintf('%s.firstname = :firstname', $rootAlias))
-//                ->setParameter('firstname', 'Loic');
+        $reseller = $this->security->getUser();
+        if ($resourceClass === Customer::class && $reseller instanceof Reseller) {
+            $rootAlias = $queryBuilder->getRootAliases()[0];
+            $queryBuilder
+                ->andWhere("$rootAlias.reseller = :reseller")
+                ->setParameter('reseller', $reseller);
         }
     }
 }

--- a/src/Entity/Reseller.php
+++ b/src/Entity/Reseller.php
@@ -2,8 +2,8 @@
 
 namespace App\Entity;
 
-//use ApiPlatform\Metadata\ApiResource;
-//use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Post;
 use App\Repository\ResellerRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -17,12 +17,12 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: ResellerRepository::class)]
 #[UniqueEntity(fields: 'email')]
-//#[ApiResource(
-//    operations: [new Post(),],
-//    denormalizationContext: [
-//        'groups' => ['reseller:write'],
-//    ]
-//)]
+#[ApiResource(
+    operations: [new Post(),],
+    denormalizationContext: [
+        'groups' => ['reseller:write'],
+    ]
+)]
 class Reseller implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]
@@ -74,7 +74,7 @@ class Reseller implements UserInterface, PasswordAuthenticatedUserInterface
 //    )]
     private ?string $companyName = null;
 
-    #[ORM\OneToMany(targetEntity: Customer::class, mappedBy: 'reseller', cascade: ['persist'])]
+    #[ORM\OneToMany(mappedBy: 'reseller', targetEntity: Customer::class, cascade: ['persist'])]
     private Collection $customers;
 
     public function __construct()
@@ -204,7 +204,7 @@ class Reseller implements UserInterface, PasswordAuthenticatedUserInterface
     {
         if (!$this->customers->contains($customer)) {
             $this->customers->add($customer);
-            $customer->addReseller($this);
+            $customer->setReseller($this);
         }
 
         return $this;
@@ -213,7 +213,9 @@ class Reseller implements UserInterface, PasswordAuthenticatedUserInterface
     public function removeCustomer(Customer $customer): static
     {
         if ($this->customers->removeElement($customer)) {
-            $customer->removeReseller($this);
+            if ($customer->getReseller() === $this) {
+                $customer->setReseller(null);
+            }
         }
 
         return $this;

--- a/src/State/CustomerProcessor.php
+++ b/src/State/CustomerProcessor.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\DeleteOperationInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+
+
+readonly class CustomerProcessor implements ProcessorInterface
+{
+    public function __construct(private Security $security, private ProcessorInterface $persistProcessor, private ProcessorInterface $removeProcessor)
+    {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = [])
+    {
+        if ($operation instanceof DeleteOperationInterface) {
+            return $this->removeProcessor->process($data, $operation, $uriVariables, $context);
+        }
+
+        $defaultContext = [
+            AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER => function (object $object, string $format, array $context): string {
+                return $object->getName();
+            },
+        ];
+
+        $reseller = $this->security->getUser();
+        $data->setReseller($reseller);
+
+        return $this->persistProcessor->process($data, $operation, $uriVariables, $defaultContext);
+    }
+}


### PR DESCRIPTION
customerProcessor to be able to persist a new customer (and delete in next future?) but needed to make the Reseller entity an API ressource again. Otherwise there was a circular reference when post a new customer with a setReseller in the processor even using the CIRCULAR_REFERENCE_HANDLER